### PR TITLE
Correction of an error in amAnalysisReplayValidationDict.json

### DIFF
--- a/tools/R/amAnalysisReplayValidationDict.json
+++ b/tools/R/amAnalysisReplayValidationDict.json
@@ -125,5 +125,18 @@
       }
     ],
     "desc": "Partial facilities table"
+  },
+  {
+    "key": "tableFacilitiesTo",
+    "mode": "list",
+    "class": "data.frame",
+    "editable": [
+      {
+        "key": "amSelect",
+        "mode": "logical",
+        "desc": "Select / unselect facility"
+      }
+    ],
+    "desc": "Partial facilities table"
   }
 ]


### PR DESCRIPTION
Hi, thanks for reviewing my pull request!

I added the item "tableFacilitiesTo" in tools/R/amAnalysisReplayValidationDict.json, so the "tableFacilitiesTo" element from the config file can be correctly parsed when running a referral analysis through the replay function. Otherwise, this element isn't taken into account when executing the amAnalysisReplayParseConf function and our "tableFacilitiesTo" object in R is of class "list" and not "data.frame" which causes an error at line 125 of tools/R/amAnalysisReferralParallel.R
Error in tableFacilitiesTo[tableFacilitiesTo$amSelect, ] :
  incorrect number of dimensions

Thank you,

Best,

Pablo